### PR TITLE
HANDY-33: add an "other" specification for customer to choose in job posting 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
 
   $SWITCH = 1
-  $SPECIALTY_TYPES = Array["Electrician", "Light Fixture", "Painter", "Plumber", "Sound System"]
+  $SPECIALTY_TYPES = Array["Electrician", "Light Fixture", "Painter", "Plumber", "Sound System", "Other"]
 
   before_action :configure_permitted_parameters, if:  :devise_controller?
 


### PR DESCRIPTION
Can now choose "Other" for specialty when making or editing a post.

closes #53 