### PR TITLE
HANDY-48: Add a "type" filter on the worker directory page

### DIFF
--- a/app/views/customer/customer_profile.html.erb
+++ b/app/views/customer/customer_profile.html.erb
@@ -1,4 +1,4 @@
-<h1><%= current_customer.first_name %>'s Profile</h1>
+<h1 class="text-center"><%= current_customer.first_name %>'s Profile</h1>
 
 <table class="table table-sm table-striped ml-4" style="max-width: 25rem;">
     <thead class="thead-dark">

--- a/app/views/worker/worker_directory.html.erb
+++ b/app/views/worker/worker_directory.html.erb
@@ -1,5 +1,56 @@
 <h1 class="text-center">Available Workers</h1>
 
+<div class="posting">
+  <a data-toggle="collapse" href="#collapseExample" role="button" aria-expanded="false" aria-controls="collapseExample">
+    Filter
+  </a>
+  <div class="collapse" id="collapseExample">
+    <li class="list-inline-item dropdown">
+      <button type="button" class="btn dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        Type
+      </button>
+      <div class="dropdown-menu">
+        <!-- loop way of displaying the menu -->
+        <% $SPECIALTY_TYPES.each_with_index do |type, index|%>
+          <p>
+            <%= link_to $SPECIALTY_TYPES.at(index).to_s, worker_directory_path(index), class: 'dropdown-item'%>
+          </p>
+        <% end %>
+        <%= link_to "See All", worker_directory_path(-1), class: 'dropdown-item'%>
+      </div>
+    </li>
+
+    <li class="list-inline-item dropdown">
+      <button type="button" class="btn dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        Example 1
+      </button>
+      <div class="dropdown-menu">
+        <!-- loop way of displaying the menu -->
+        <% $SPECIALTY_TYPES.each_with_index do |type, index|%>
+          <p>
+            <%= link_to $SPECIALTY_TYPES.at(index).to_s, worker_directory_path(index), class: 'dropdown-item'%>
+          </p>
+        <% end %>
+        <%= link_to "See All", worker_directory_path(-1), class: 'dropdown-item'%>
+      </div>
+    </li>
+
+    <li class="list-inline-item dropdown">
+      <button type="button" class="btn dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        Example 2
+      </button>
+      <div class="dropdown-menu">
+        <!-- loop way of displaying the menu -->
+        <% $SPECIALTY_TYPES.each_with_index do |type, index|%>
+          <p>
+            <%= link_to $SPECIALTY_TYPES.at(index).to_s, worker_directory_path(index), class: 'dropdown-item'%>
+          </p>
+        <% end %>
+        <%= link_to "See All", worker_directory_path(-1), class: 'dropdown-item'%>
+      </div>
+    </li>
+  </div>
+
 <p></p>
 
 <table class="table table-hover">

--- a/app/views/worker/worker_profile.html.erb
+++ b/app/views/worker/worker_profile.html.erb
@@ -1,4 +1,4 @@
-<h1><%= current_worker.first_name %>'s Profile</h1>
+<h1 class="text-center"><%= current_worker.first_name %>'s Profile</h1>
 
 <table class="table table-sm table-striped ml-4" style="max-width: 25rem;">
     <thead class="thead-dark">


### PR DESCRIPTION
close #64 
added code to worker_directory html for type filter; centered heading on worker and customer profile page

left additional code in the worker_directory html for the other filter categories; look for Example 1 and Example 2