### PR TITLE
HANDY-40: Add dynamic scrolling to the services dropdown

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,6 +21,14 @@
   "custom-color": #456C97
 );
 
+// The following block adjust the navbar's "Services" dropdown to scroll 
+// only when the content of the scroll doesn't fit on the screen. 
+@media (max-width: 570px ),(max-height: 100vh) {
+  .dropdown-menu{
+      max-height:100vh;
+      overflow:scroll;
+  }
+}
 
  @import "bootstrap/scss/bootstrap";
  @import "bootswatch/dist/yeti/bootswatch";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,12 +23,10 @@
 
 // The following block adjust the navbar's "Services" dropdown to scroll 
 // only when the content of the scroll doesn't fit on the screen. 
-@media (max-width: 570px ),(max-height: 100vh) {
-  .dropdown-menu{
-      max-height:100vh;
-      overflow:scroll;
+ .dropdown-menu{
+   max-height:50vh;
+   overflow:auto;
   }
-}
 
  @import "bootstrap/scss/bootstrap";
  @import "bootswatch/dist/yeti/bootswatch";

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
 
   $SWITCH = 1
-  $SPECIALTY_TYPES = Array["Electrician", "Light Fixture", "Painter", "Plumber", "Sound System", "Other"]
+  $SPECIALTY_TYPES = Array["Electrician", "Light Fixture", "Painter", "Plumber", "Sound System", "Carpenter", "Computer Repair Servicer", "Other"]
 
   before_action :configure_permitted_parameters, if:  :devise_controller?
 


### PR DESCRIPTION
Closes: #93 

Task Outcome: completed as planned.

How to Evaluate: Check all the dropdowns that have to do with the specialty types, and there should be dynamic scrolling when the dropdown reaches about 50% of the page